### PR TITLE
Source files formatting.

### DIFF
--- a/rabbit.go
+++ b/rabbit.go
@@ -164,13 +164,13 @@ func (c Config) generateProperty(params ...Param) string {
 				param.Value,
 			)
 		case "public":
-			generatedParams = fmt.Sprintf(
+			generatedParams += fmt.Sprintf(
 				"s:%d:\"%s\";s:%d:\"%s\";",
 				len(param.Name), param.Name, len(param.Value),
 				param.Value,
 			)
 		default:
-			generatedParams = fmt.Sprintf(
+			generatedParams += fmt.Sprintf(
 				"s:%d:\"%s\";s:%d:\"%s\";",
 				len(param.Name), param.Name, len(param.Value),
 				param.Value,

--- a/rabbit_test.go
+++ b/rabbit_test.go
@@ -3,8 +3,9 @@ package rabbit
 import (
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGeneratePublicProperty(t *testing.T) {
@@ -41,7 +42,11 @@ func TestGenerateProtectedProperty(t *testing.T) {
 	c := Config{Job: "testJob"}
 	generatedParams := c.generateProperty(params...)
 
-	expectedParams := fmt.Sprintf("s:%d:\"\u0000*\u0000%s\";s:%d:\"%s\";", len("paramName")+3, "paramName", len("paramValue"), "paramValue")
+	expectedParams := fmt.Sprintf(
+		"s:%d:\"\u0000*\u0000%s\";s:%d:\"%s\";",
+		len("paramName")+3, "paramName", len("paramValue"),
+		"paramValue",
+	)
 
 	assert.Equal(t, expectedParams, generatedParams)
 }
@@ -54,7 +59,11 @@ func TestGeneratePrivateProperty(t *testing.T) {
 	c := Config{Job: "testJob"}
 	generatedParams := c.generateProperty(params...)
 
-	expectedParams := fmt.Sprintf("s:%d:\"\u0000%s\u0000%s\";s:%d:\"%s\";", len(c.Job)+2, c.Job, "paramName", len("paramValue"), "paramValue")
+	expectedParams := fmt.Sprintf(
+		"s:%d:\"\u0000%s\u0000%s\";s:%d:\"%s\";",
+		len(c.Job)+2, c.Job, "paramName", len("paramValue"),
+		"paramValue",
+	)
 
 	assert.Equal(t, expectedParams, generatedParams)
 }


### PR DESCRIPTION

    -   Split long lines into shorter lines for better
        readability on smaller screen/window size.
    -   Corrected import statements to conform to the
        standard recommended style.
    -   Removed break statements from the case clauses, as
        go standard inhibits default fall-through.